### PR TITLE
Add SciPy dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ On Windows, the library uses the default audio drivers. No additional setup is r
 pip install fujielab-audio-mcnr_input
 ```
 
+This command installs the library along with its Python dependencies such as
+NumPy, **SciPy (>=1.0)**, SoundDevice, SoundFile, and SoundCard.
+
 ## Quick Start
 
 ### Basic Usage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "sounddevice>=0.4.0",
     "soundfile>=0.10.0",
     "soundcard>=0.4.0",
+    "scipy>=1.0",
     "pywin32>=227; sys_platform == 'win32'",
 ]
 


### PR DESCRIPTION
## Summary
- include `scipy>=1.0` in project dependencies
- mention SciPy requirement in installation docs

## Testing
- `pip install -e .` *(fails: cannot connect to pypi.org)*
- `pytest` *(fails: unrecognized arguments due to missing pytest-cov)*

------
https://chatgpt.com/codex/tasks/task_e_685d4eb67294832fbeb0840a502038a0