### PR TITLE
Implement read method

### DIFF
--- a/fujielab/audio/mcnr_input/core.py
+++ b/fujielab/audio/mcnr_input/core.py
@@ -305,6 +305,32 @@ class InputStream:
         """
         return self.active()
 
+    def read(self, block=True, timeout=None):
+        """
+        Read processed audio data from the internal queue.
+
+        内部キューから処理済みオーディオデータを取得する
+
+        Parameters
+        ----------
+        block : bool, optional
+            Whether to block until data is available (default: True)
+            データが利用可能になるまで待機するかどうか（デフォルト: True）
+        timeout : float or None, optional
+            Maximum time to wait in seconds (default: None)
+            待機する最大時間（秒）（デフォルト: None）
+
+        Returns
+        -------
+        np.ndarray or None
+            Retrieved audio data or ``None`` if the queue was empty
+            取得したオーディオデータ。キューが空の場合は ``None``
+        """
+        try:
+            return self.data_queue.get(block=block, timeout=timeout)
+        except queue.Empty:
+            return None
+
     def _start_stream(self):
         """内部実装: ストリームを開始する"""
         import platform

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -117,6 +117,17 @@ class TestInputStream:
         # and is skipped in automated testing
         pass
 
+    def test_read_returns_queue_data(self):
+        """read() should return data placed in the queue"""
+        stream = InputStream(debug=False)
+        sample = np.random.rand(10, 2).astype(np.float32)
+        stream.data_queue.put(sample)
+
+        result = stream.read(block=False)
+
+        assert isinstance(result, np.ndarray)
+        assert np.array_equal(result, sample)
+
 
 class TestPlatformDetection:
     """Test platform-specific imports"""


### PR DESCRIPTION
## Summary
- implement `read()` in `InputStream` to fetch data from `data_queue`
- test that `read()` returns queued data

## Testing
- `pytest -q --override-ini addopts=` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_685d4e832f94832f9b906198719a42e6