### PR TITLE
Refactor backend OutputCapture interface

### DIFF
--- a/fujielab/audio/mcnr_input/_backend/output_capture.py
+++ b/fujielab/audio/mcnr_input/_backend/output_capture.py
@@ -1,119 +1,33 @@
-"""
-Output Audio Capture Unified Interface Module
-
-This module provides a unified interface for output capture implementations for macOS and Windows.
-It hides the details of platform-specific implementations and makes them accessible through a consistent API.
-
-Usage example:
-    from ._backend import output_capture
-
-    # Create an instance
-    capture = output_capture.create_output_capture_instance(
-        sample_rate=16000, channels=2
-    )
-
-    # Start capture
-    capture.start_audio_capture(device_name="BlackHole 2ch")
-
-    # Read audio data
-    audio_data = capture.read_audio_capture()
-
-    # Stop capture
-    capture.stop_audio_capture()
-"""
+"""Unified OutputCapture interface selecting platform implementation."""
 
 import platform
-import numpy as np
-import time
-import sounddevice as sd
-import subprocess
-from .data import AudioData
 
-# Import platform-specific implementations
+from .output_capture_base import OutputCapture as OutputCaptureBase
+
 if platform.system() == "Darwin":
-    from .output_capture_mac import OutputCaptureMac, AudioData
+    from .output_capture_mac import (
+        OutputCaptureMac as OutputCapture,
+        create_output_capture_instance,
+        list_devices,
+        check_fujielab_output_device,
+    )
 else:
-    from .output_capture_win import OutputCaptureWin, AudioData
+    from .output_capture_win import (
+        OutputCaptureWin as OutputCapture,
+        create_output_capture_instance,
+        list_devices,
+    )
 
-
-# Provide platform-appropriate output capture class
-def create_output_capture_instance(sample_rate=44100, channels=2, blocksize=None):
-    """
-    Create an appropriate output capture instance for the platform
-
-    Parameters:
-    -----------
-    sample_rate : int, optional
-        Sampling rate (Hz) (default: 44100Hz)
-    channels : int, optional
-        Number of channels (default: 2 channels (stereo))
-    blocksize : int, optional
-        Block size (number of frames) (uses platform default if not specified)
-
-    Returns:
-    --------
-    OutputCapture
-        Platform-appropriate output capture instance
-    """
-    if blocksize is None:
-        blocksize = 1024 if platform.system() == "Darwin" else 512
-
-    if platform.system() == "Darwin":
-        return OutputCaptureMac(
-            sample_rate=sample_rate, channels=channels, blocksize=blocksize
-        )
-    else:
-        return OutputCaptureWin(
-            sample_rate=sample_rate, channels=channels, blocksize=blocksize
-        )
-
-
-def list_devices():
-    """
-    List available audio devices
-
-    Returns:
-    --------
-    bool
-        True if successful, False if failed
-    """
-    # Call the list display method according to each platform
-    if platform.system() == "Darwin":
-        return OutputCaptureMac.list_audio_devices()
-    else:
-        # Use Windows-specific list_audio_devices if available
-        if hasattr(OutputCaptureWin, "list_audio_devices"):
-            return OutputCaptureWin.list_audio_devices()
-        else:
-            print("\nAvailable audio output devices:")
-            try:
-                devices = sd.query_devices()
-                for i, dev in enumerate(devices):
-                    if dev["max_output_channels"] > 0:
-                        print(
-                            f"[{i}] {dev['name']} (Output Channels: {dev['max_output_channels']}, Host: {dev.get('hostapi')})"
-                        )
-
-                print(
-                    "\nTo capture output on Windows, use the output device labeled 'WASAPI'."
-                )
-                return True
-            except Exception as e:
-                print(f"Error retrieving device list: {e}")
-                return False
-
-
-def check_fujielab_output_device():
-    """
-    Check if the fujielab-output composite device (macOS only) is set up correctly
-
-    Returns:
-    --------
-    bool
-        True if set up correctly, False if there is a problem
-    """
-    if platform.system() == "Darwin":
-        return OutputCaptureMac.check_fujielab_output_device()
-    else:
+    def check_fujielab_output_device(debug: bool = False) -> bool:
+        """Stub for macOS-only feature."""
         print("This feature is only supported on macOS")
         return False
+
+
+__all__ = [
+    "OutputCapture",
+    "OutputCaptureBase",
+    "create_output_capture_instance",
+    "list_devices",
+    "check_fujielab_output_device",
+]

--- a/fujielab/audio/mcnr_input/_backend/output_capture_mac.py
+++ b/fujielab/audio/mcnr_input/_backend/output_capture_mac.py
@@ -585,6 +585,32 @@ class OutputCaptureMac(OutputCapture):
                 self._debug_print("Stream initialization failed, resetting state")
                 self._stream_initialized = False
 
+
+# Module level helper functions matching InputCapture pattern
+def create_output_capture_instance(
+    sample_rate: int = 44100,
+    channels: int = 2,
+    blocksize: int = 1024,
+    debug: bool = False,
+) -> "OutputCaptureMac":
+    """Create a macOS OutputCapture instance"""
+    return OutputCaptureMac(
+        sample_rate=sample_rate,
+        channels=channels,
+        blocksize=blocksize,
+        debug=debug,
+    )
+
+
+def list_devices() -> bool:
+    """List available audio devices on macOS"""
+    return OutputCaptureMac.list_audio_devices()
+
+
+def check_fujielab_output_device(debug: bool = False) -> bool:
+    """Check fujielab-output composite device"""
+    return OutputCaptureMac.check_fujielab_output_device(debug=debug)
+
     @staticmethod
     def _check_required_tools():
         """
@@ -772,7 +798,13 @@ class OutputCaptureMac(OutputCapture):
 
 
 # Export necessary classes as a module
-__all__ = ["OutputCapture", "OutputCaptureMac"]
+__all__ = [
+    "OutputCapture",
+    "OutputCaptureMac",
+    "create_output_capture_instance",
+    "list_devices",
+    "check_fujielab_output_device",
+]
 
 
 if __name__ == "__main__":

--- a/fujielab/audio/mcnr_input/_backend/output_capture_win.py
+++ b/fujielab/audio/mcnr_input/_backend/output_capture_win.py
@@ -8,6 +8,7 @@ import numpy as np
 import threading
 import time
 import queue
+import sounddevice as sd
 from .data import AudioData
 from .output_capture_base import OutputCapture
 
@@ -430,5 +431,44 @@ class OutputCaptureWin(OutputCapture):
         self._debug_print("Audio capture stopped")
 
 
+# Module level helper functions matching InputCapture pattern
+def create_output_capture_instance(
+    sample_rate: int = 44100,
+    channels: int = 2,
+    blocksize: int = 512,
+    debug: bool = False,
+) -> "OutputCaptureWin":
+    """Create a Windows OutputCapture instance"""
+    return OutputCaptureWin(
+        sample_rate=sample_rate,
+        channels=channels,
+        blocksize=blocksize,
+        debug=debug,
+    )
+
+
+def list_devices() -> bool:
+    """List available audio output devices on Windows"""
+    if hasattr(OutputCaptureWin, "list_audio_devices"):
+        return OutputCaptureWin.list_audio_devices()
+    print("\nAvailable audio output devices:")
+    try:
+        devices = sd.query_devices()
+        for i, dev in enumerate(devices):
+            if dev["max_output_channels"] > 0:
+                print(
+                    f"[{i}] {dev['name']} (Output Channels: {dev['max_output_channels']}, Host: {dev.get('hostapi')})"
+                )
+        print("\nTo capture output on Windows, use the output device labeled 'WASAPI'.")
+        return True
+    except Exception as e:
+        print(f"Error retrieving device list: {e}")
+        return False
+
+
 # Export the necessary class as a module
-__all__ = ["OutputCaptureWin"]
+__all__ = [
+    "OutputCaptureWin",
+    "create_output_capture_instance",
+    "list_devices",
+]

--- a/fujielab/audio/mcnr_input/core.py
+++ b/fujielab/audio/mcnr_input/core.py
@@ -10,11 +10,8 @@ from typing import Optional, List, Union, Dict, Any
 from ._backend.data import AudioData
 from ._backend.input_capture import InputCapture, InputCaptureBase
 
-# Import OutputCapture class according to the platform
-if platform.system() == "Darwin":
-    from ._backend.output_capture_mac import OutputCaptureMac as OutputCapture
-else:
-    from ._backend.output_capture_win import OutputCaptureWin as OutputCapture
+# Unified OutputCapture interface
+from ._backend.output_capture import OutputCapture
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- unify platform specific output capture imports similar to input capture
- expose helper factory and device listing functions per platform
- simplify core import of OutputCapture

## Testing
- `black fujielab/audio/mcnr_input/_backend/output_capture.py fujielab/audio/mcnr_input/_backend/output_capture_mac.py fujielab/audio/mcnr_input/_backend/output_capture_win.py fujielab/audio/mcnr_input/core.py`
- `flake8` *(fails: command not found)*
- `pytest -q` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_685dd7ce3084832f8872ff53fab2e177